### PR TITLE
Remove CORS Check

### DIFF
--- a/complete/src/main/java/com/example/restservice/RestServiceApplication.java
+++ b/complete/src/main/java/com/example/restservice/RestServiceApplication.java
@@ -1,7 +1,6 @@
 package com.example.restservice;
 
 import java.util.Collections;
-import java.util.List;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/complete/src/main/java/com/example/restservice/RestServiceApplication.java
+++ b/complete/src/main/java/com/example/restservice/RestServiceApplication.java
@@ -21,13 +21,7 @@ public class RestServiceApplication {
     UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
     CorsConfiguration config = new CorsConfiguration();
     config.setAllowCredentials(true);
-    config.setAllowedOrigins(
-        List.of(
-            "https://simplq.me",
-            "https://www.simplq.me",
-            "https://dev.simplq.me",
-            "https://new.simplq.me",
-            "http://localhost:3000"));
+    config.setAllowedOrigins(Collections.singletonList("*"));
     config.setAllowedMethods(Collections.singletonList("*"));
     config.setAllowedHeaders(Collections.singletonList("*"));
     source.registerCorsConfiguration("/**", config);


### PR DESCRIPTION
For us, I don't see any security advantage of using CORS. Mostly I think we would be able to prevent some other website to use our backend as their queue backend, but I am not very concerned about it.

Disabling CORS check for now, this is required for preview environments as well