### PR TITLE
Use Anonymous User for Integration Test

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The project is written in Java, and deployed on AWS. These steps are to be follo
 3. Build the jar:
 
 ```
-mvn package -DskipTests
+mvn package
 ```
 
 4. Run the jar:
@@ -28,16 +28,10 @@ We follow Google's [Java Style Guidelines](https://github.com/google/styleguide)
 
 Test APIs through Postman - A test postman collection is available [here](https://www.getpostman.com/collections/252a096a86fc550fb5fb).
 
-Integration Tests Setup: 
+Run Integration Tests: 
 
-1. Copy the bearer token from Authorization header in Postman
-2. Add the following to application.properties file (DO NOT COMMIT THE TOKEN)  
 ```
-auth.token=Bearer <token string from step 1>
-```
-Confirm that the setup is done correctly by running 
-```
-mvn clean package
+mvn test
 ```
 
 

--- a/simplq/src/test/java/me/simplq/IntegrationTests.java
+++ b/simplq/src/test/java/me/simplq/IntegrationTests.java
@@ -1,5 +1,10 @@
 package me.simplq;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import me.simplq.config.TestConfig;
 import me.simplq.controller.model.queue.CreateQueueResponse;
@@ -10,7 +15,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
@@ -18,11 +22,6 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
-
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
@@ -36,8 +35,7 @@ class IntegrationTests {
 
   @Autowired private ObjectMapper objectMapper;
 
-  @Value("${auth.token}")
-  private String authToken;
+  private String authToken = "anonymous";
 
   @Test
   void endToEndScenarioTest() throws Exception {


### PR DESCRIPTION
We handle sending `Authorization: Bearer anonymous` as a special case, in which the username is set to anonymous. 

This can be used for running our basic E2E checks.