### PR TITLE
Backend Support for Queue History

### DIFF
--- a/simplq/src/main/java/me/simplq/controller/model/queue/QueueDetailsResponse.java
+++ b/simplq/src/main/java/me/simplq/controller/model/queue/QueueDetailsResponse.java
@@ -41,4 +41,18 @@ public class QueueDetailsResponse {
             token.getStatus(),
             token.getNotifiable()));
   }
+
+  public void addDeletedToken(me.simplq.dao.Token token) {                                    
+    this.deletedTokens.add(                                                                   
+    new Token(                                                                            
+    token.getName(),                                                                  
+    token.getContactNumber(),                                                         
+    token.getTokenId(),                                                               
+    token.getTokenNumber(),                                                           
+    token.getTokenCreationTimestamp(),                                                
+    token.getStatus(),                                                                
+    token.getNotifiable()));                                                          
+    
+  }                                                                                           
 }
+

--- a/simplq/src/main/java/me/simplq/dao/Token.java
+++ b/simplq/src/main/java/me/simplq/dao/Token.java
@@ -39,6 +39,7 @@ public class Token {
   @Column(updatable = false)
   @Temporal(TemporalType.TIMESTAMP)
   Date tokenCreationTimestamp;
+  Date tokenDeletionTimestamp;
 
   public Token(
       String name, String contactNumber, TokenStatus status, Boolean notifiable, String ownerId) {
@@ -53,6 +54,7 @@ public class Token {
   public String getTokenUrl() {
     return URL_PREFIX + tokenId;
   }
+
 
   public Long getAheadCount() {
     if (this.getStatus() == TokenStatus.REMOVED) {

--- a/simplq/src/main/java/me/simplq/service/QueueService.java
+++ b/simplq/src/main/java/me/simplq/service/QueueService.java
@@ -123,6 +123,10 @@ public class QueueService {
                   .filter(token -> token.getStatus() != TokenStatus.REMOVED)
                   .sorted(Comparator.comparing(Token::getTokenCreationTimestamp))
                   .forEach(resp::addToken);
+              queue.getTokens().stream()
+                  .filter(token -> token.getStatus() == TokenStatus.REMOVED)
+                  .sorted(Comparator.comparing(Token::getTokenCreationTimestamp))
+                  .forEach(resp::addDeletedToken);
               return resp;
             })
         .orElseThrow(SQInvalidRequestException::queueNotFoundException);

--- a/simplq/src/main/java/me/simplq/service/TokenService.java
+++ b/simplq/src/main/java/me/simplq/service/TokenService.java
@@ -2,6 +2,7 @@ package me.simplq.service;
 
 import java.util.Comparator;
 import java.util.stream.Collectors;
+import java.util.Date;
 import javax.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import me.simplq.constants.QueueStatus;
@@ -57,6 +58,11 @@ public class TokenService {
   @Transactional
   public TokenDeleteResponse deleteToken(String tokenId) {
     tokenRepository.setTokenStatusById(TokenStatus.REMOVED, tokenId);
+    /*Set Token Deletion timestamp to now*/
+    Date nowTime = new Date();
+
+    tokenRepository.findById(tokenId).get().setTokenDelete( nowTime);
+
     return tokenRepository
         .findById(tokenId)
         .map(


### PR DESCRIPTION
Implements the features in ticket #126 
Creates a deletion timestamp for each token when it is deleted
Keeps a list of deleted tokens in the QueueDetailsResponse object