### PR TITLE
Refactor QueueService, use predicates, useEntity

### DIFF
--- a/simplq/src/main/java/me/simplq/controller/model/queue/MyQueuesResponse.java
+++ b/simplq/src/main/java/me/simplq/controller/model/queue/MyQueuesResponse.java
@@ -13,12 +13,20 @@ public class MyQueuesResponse {
   public MyQueuesResponse() {
     this.queues = new ArrayList<>();
   }
-
+  
   @Data
   public static class Queue {
+
     private final String queueId;
     private final String queueName;
     private final Date queueCreationTimestamp;
+
+    public static Queue fromEntity(me.simplq.dao.Queue queue) {
+      return new MyQueuesResponse.Queue(
+          queue.getQueueId(),
+          queue.getQueueName(),
+          queue.getQueueCreationTimestamp());
+    }
   }
 
   private final List<Queue> queues;

--- a/simplq/src/main/java/me/simplq/controller/model/queue/QueueDetailsResponse.java
+++ b/simplq/src/main/java/me/simplq/controller/model/queue/QueueDetailsResponse.java
@@ -1,11 +1,13 @@
 package me.simplq.controller.model.queue;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import lombok.Data;
 import me.simplq.constants.QueueStatus;
 import me.simplq.constants.TokenStatus;
+import me.simplq.dao.Queue;
 
 @Data
 public class QueueDetailsResponse {
@@ -40,5 +42,21 @@ public class QueueDetailsResponse {
             token.getTokenCreationTimestamp(),
             token.getStatus(),
             token.getNotifiable()));
+  }
+
+  public static QueueDetailsResponse fromEntity(Queue queue) {
+    var response = new QueueDetailsResponse(
+        queue.getQueueId(),
+        queue.getQueueName(),
+        queue.getQueueCreationTimestamp(),
+        queue.getStatus(),
+        queue.getMaxQueueCapacity(),
+        queue.getSlotsLeft(),
+        queue.isSelfJoinAllowed());
+    queue.getTokens().stream()
+        .filter(token -> token.getStatus() != TokenStatus.REMOVED)
+        .sorted(Comparator.comparing(me.simplq.dao.Token::getTokenCreationTimestamp))
+        .forEach(response::addToken);
+    return response;
   }
 }

--- a/simplq/src/main/java/me/simplq/controller/model/queue/QueueStatusResponse.java
+++ b/simplq/src/main/java/me/simplq/controller/model/queue/QueueStatusResponse.java
@@ -3,6 +3,7 @@ package me.simplq.controller.model.queue;
 import java.util.Date;
 import lombok.Data;
 import me.simplq.constants.QueueStatus;
+import me.simplq.dao.Queue;
 
 @Data
 public class QueueStatusResponse {
@@ -17,4 +18,17 @@ public class QueueStatusResponse {
   final Long slotsLeft;
   final Date queueCreationTimestamp;
   final boolean isSelfJoinAllowed;
+
+  public static QueueStatusResponse fromEntity(Queue queue) {
+    return new QueueStatusResponse(
+        queue.getQueueId(),
+        queue.getQueueName(),
+        queue.getStatus(),
+        queue.getMaxQueueCapacity(),
+        queue.getActiveTokensCount(),
+        queue.getTotalTokensCount(),
+        queue.getSlotsLeft(),
+        queue.getQueueCreationTimestamp(),
+        queue.isSelfJoinAllowed());
+  }
 }

--- a/simplq/src/main/java/me/simplq/controller/model/queue/UpdateQueueStatusResponse.java
+++ b/simplq/src/main/java/me/simplq/controller/model/queue/UpdateQueueStatusResponse.java
@@ -2,10 +2,17 @@ package me.simplq.controller.model.queue;
 
 import lombok.Data;
 import me.simplq.constants.QueueStatus;
+import me.simplq.dao.Queue;
 
 @Data
 public class UpdateQueueStatusResponse {
+
   public final String queueId;
   public final String queueName;
   public final QueueStatus status;
+
+  public static UpdateQueueStatusResponse fromEntity(Queue queue) {
+    return new UpdateQueueStatusResponse(queue.getQueueId(), queue.getQueueName(),
+        queue.getStatus());
+  }
 }

--- a/simplq/src/main/java/me/simplq/dao/Queue.java
+++ b/simplq/src/main/java/me/simplq/dao/Queue.java
@@ -64,6 +64,10 @@ public class Queue {
         .count();
   }
 
+  public long getTotalTokensCount() {
+    return tokens.size();
+  }
+
   public boolean isFull() {
     return getSlotsLeft() <= 0;
   }

--- a/simplq/src/main/java/me/simplq/service/QueueService.java
+++ b/simplq/src/main/java/me/simplq/service/QueueService.java
@@ -6,7 +6,6 @@ import java.util.stream.Collectors;
 import javax.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import me.simplq.constants.QueueStatus;
-import me.simplq.constants.TokenStatus;
 import me.simplq.controller.advices.LoggedInUserInfo;
 import me.simplq.controller.model.queue.CreateQueueRequest;
 import me.simplq.controller.model.queue.CreateQueueResponse;
@@ -19,10 +18,8 @@ import me.simplq.controller.model.queue.QueueStatusResponse;
 import me.simplq.controller.model.queue.UpdateQueueStatusResponse;
 import me.simplq.dao.Queue;
 import me.simplq.dao.QueueRepository;
-import me.simplq.dao.Token;
-import me.simplq.exceptions.SQAccessDeniedException;
-import me.simplq.exceptions.SQInternalServerException;
 import me.simplq.exceptions.SQInvalidRequestException;
+import me.simplq.utils.predicates.QueueThrowingPredicate;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 
@@ -30,10 +27,10 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class QueueService {
 
-  private static final String ACCESS_DENIED_ERROR_TEXT = "You do not have access to this queue";
   private final QueueRepository queueRepository;
   private final OwnerService ownerService;
   private final LoggedInUserInfo loggedInUserInfo;
+  private final QueueThrowingPredicate queueThrowingPredicate;
 
   @Transactional
   public CreateQueueResponse createQueue(CreateQueueRequest createQueueRequest) {
@@ -50,81 +47,44 @@ public class QueueService {
 
   @Transactional
   public UpdateQueueStatusResponse pauseQueue(PauseQueueRequest pauseQueueRequest, String queueId) {
-    try {
-      var queue =
-          queueRepository
-              .findById(queueId)
-              .map(
-                  queue1 -> {
-                    if (!queue1.getOwner().getId().equals(loggedInUserInfo.getUserId())) {
-                      throw new SQAccessDeniedException(ACCESS_DENIED_ERROR_TEXT);
-                    }
-                    if (queue1.getStatus().equals(QueueStatus.DELETED)) {
-                      throw SQInvalidRequestException.queueDeletedException();
-                    }
-                    if (pauseQueueRequest.getStatus().equals(QueueStatus.DELETED)) {
-                      throw SQInvalidRequestException.queueDeletedNotAllowedException();
-                    }
-                    queue1.setStatus(pauseQueueRequest.getStatus());
-                    return queueRepository.save(queue1);
-                  })
-              .orElseThrow();
-      return new UpdateQueueStatusResponse(
-          queue.getQueueId(), queue.getQueueName(), queue.getStatus());
-    } catch (Exception e) {
-      throw new SQInternalServerException("Unable to update queue: ", e);
-    }
+    return queueRepository
+        .findById(queueId)
+        .map(
+            queue1 -> {
+              queueThrowingPredicate.isNotDeleted()
+                  .and(queueThrowingPredicate.currentUserOwnsQueue())
+                  .test(queue1);
+              if (pauseQueueRequest.getStatus().equals(QueueStatus.DELETED)) {
+                throw SQInvalidRequestException.queueDeletedNotAllowedException();
+              }
+              queue1.setStatus(pauseQueueRequest.getStatus());
+              return queueRepository.save(queue1);
+            })
+        .map(UpdateQueueStatusResponse::fromEntity)
+        .orElseThrow(SQInvalidRequestException::queueNotFoundException);
   }
 
   @Transactional
   public UpdateQueueStatusResponse deleteQueue(String queueId) {
-    try {
-      var queue =
-          queueRepository
-              .findById(queueId)
-              .map(
-                  queue1 -> {
-                    if (!queue1.getOwner().getId().equals(loggedInUserInfo.getUserId())) {
-                      throw new SQAccessDeniedException(ACCESS_DENIED_ERROR_TEXT);
-                    }
-                    if (queue1.getStatus().equals(QueueStatus.DELETED)) {
-                      throw SQInvalidRequestException.queueDeletedException();
-                    }
-                    queue1.setStatus(QueueStatus.DELETED);
-                    return queueRepository.save(queue1);
-                  })
-              .orElseThrow();
-      return new UpdateQueueStatusResponse(
-          queue.getQueueId(), queue.getQueueName(), queue.getStatus());
-    } catch (Exception e) {
-      throw new SQInternalServerException("Unable to delete queue: ", e);
-    }
+    return queueRepository
+        .findById(queueId)
+        .map(
+            queue1 -> {
+              queueThrowingPredicate.isNotDeleted()
+                  .and(queueThrowingPredicate.currentUserOwnsQueue())
+                  .test(queue1);
+              queue1.setStatus(QueueStatus.DELETED);
+              return queueRepository.save(queue1);
+            })
+        .map(UpdateQueueStatusResponse::fromEntity)
+        .orElseThrow(SQInvalidRequestException::queueNotFoundException);
   }
 
   @Transactional
   public QueueDetailsResponse getQueueDetails(String queueId) {
     return queueRepository
-        .findById(queueId)
-        .map(
-            queue -> {
-              if (!queue.getOwner().getId().equals(loggedInUserInfo.getUserId())) {
-                throw new SQAccessDeniedException(ACCESS_DENIED_ERROR_TEXT);
-              }
-              var resp =
-                  new QueueDetailsResponse(
-                      queueId,
-                      queue.getQueueName(),
-                      queue.getQueueCreationTimestamp(),
-                      queue.getStatus(),
-                      queue.getMaxQueueCapacity(),
-                      queue.getSlotsLeft(),
-                      queue.isSelfJoinAllowed());
-              queue.getTokens().stream()
-                  .filter(token -> token.getStatus() != TokenStatus.REMOVED)
-                  .sorted(Comparator.comparing(Token::getTokenCreationTimestamp))
-                  .forEach(resp::addToken);
-              return resp;
-            })
+        .findById(queueId).filter(queueThrowingPredicate.currentUserOwnsQueue())
+        .map(QueueDetailsResponse::fromEntity)
         .orElseThrow(SQInvalidRequestException::queueNotFoundException);
   }
 
@@ -132,20 +92,7 @@ public class QueueService {
   public QueueStatusResponse getQueueStatus(String queueId) {
     return queueRepository
         .findById(queueId)
-        .map(
-            queue ->
-                new QueueStatusResponse(
-                    queueId,
-                    queue.getQueueName(),
-                    queue.getStatus(),
-                    queue.getMaxQueueCapacity(),
-                    queue.getTokens().stream()
-                        .filter(user -> user.getStatus().equals(TokenStatus.WAITING))
-                        .count(),
-                    Long.valueOf(queue.getTokens().size()),
-                    queue.getSlotsLeft(),
-                    queue.getQueueCreationTimestamp(),
-                    queue.isSelfJoinAllowed()))
+        .map(QueueStatusResponse::fromEntity)
         .orElseThrow(SQInvalidRequestException::queueNotFoundException);
   }
 
@@ -154,14 +101,9 @@ public class QueueService {
     return new MyQueuesResponse(
         queueRepository
             .findByOwnerId(loggedInUserInfo.getUserId())
-            .filter(queue -> queue.getStatus() != QueueStatus.DELETED)
+            .filter(queue -> !QueueStatus.DELETED.equals(queue.getStatus()))
             .sorted(Comparator.comparing(Queue::getQueueCreationTimestamp))
-            .map(
-                queue ->
-                    new MyQueuesResponse.Queue(
-                        queue.getQueueId(),
-                        queue.getQueueName(),
-                        queue.getQueueCreationTimestamp()))
+            .map(MyQueuesResponse.Queue::fromEntity)
             .collect(Collectors.toList()));
   }
 
@@ -169,20 +111,7 @@ public class QueueService {
   public QueueStatusResponse getQueueStatusByName(String queueName) {
     return queueRepository
         .findByQueueName(queueName)
-        .map(
-            queue ->
-                new QueueStatusResponse(
-                    queue.getQueueId(),
-                    queue.getQueueName(),
-                    queue.getStatus(),
-                    queue.getMaxQueueCapacity(),
-                    queue.getTokens().stream()
-                        .filter(user -> user.getStatus().equals(TokenStatus.WAITING))
-                        .count(),
-                    Long.valueOf(queue.getTokens().size()),
-                    queue.getSlotsLeft(),
-                    queue.getQueueCreationTimestamp(),
-                    queue.isSelfJoinAllowed()))
+        .map(QueueStatusResponse::fromEntity)
         .orElseThrow(SQInvalidRequestException::queueNotFoundException);
   }
 

--- a/simplq/src/main/java/me/simplq/utils/predicates/QueueThrowingPredicate.java
+++ b/simplq/src/main/java/me/simplq/utils/predicates/QueueThrowingPredicate.java
@@ -1,0 +1,59 @@
+package me.simplq.utils.predicates;
+
+import java.util.function.Predicate;
+import lombok.RequiredArgsConstructor;
+import me.simplq.constants.QueueStatus;
+import me.simplq.controller.advices.LoggedInUserInfo;
+import me.simplq.dao.Queue;
+import me.simplq.exceptions.SQAccessDeniedException;
+import me.simplq.exceptions.SQInvalidRequestException;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class QueueThrowingPredicate {
+
+  private static final String ACCESS_DENIED_ERROR_TEXT = "You do not have access to this queue";
+
+  private final LoggedInUserInfo loggedInUserInfo;
+
+  public Predicate<Queue> isNotPaused() {
+    return queue -> {
+      if (queue.getStatus() == QueueStatus.PAUSED) {
+        throw SQInvalidRequestException.queuePausedException();
+      }
+
+      return true;
+    };
+  }
+
+  public Predicate<Queue> isNotDeleted() {
+    return queue -> {
+      if (queue.getStatus() == QueueStatus.DELETED) {
+        throw SQInvalidRequestException.queueDeletedException();
+      }
+
+      return true;
+    };
+  }
+
+  public Predicate<Queue> isNotFull() {
+    return queue -> {
+      if (queue.isFull()) {
+        throw SQInvalidRequestException.queueDeletedException();
+      }
+
+      return true;
+    };
+  }
+
+  public Predicate<Queue> currentUserOwnsQueue() {
+    return queue -> {
+      if (queue.getOwner().getId().equals(loggedInUserInfo.getUserId())) {
+        return true;
+      }
+
+      throw new SQAccessDeniedException(ACCESS_DENIED_ERROR_TEXT);
+    };
+  }
+}

--- a/simplq/src/main/java/me/simplq/utils/predicates/TokenPredicate.java
+++ b/simplq/src/main/java/me/simplq/utils/predicates/TokenPredicate.java
@@ -1,0 +1,19 @@
+package me.simplq.utils.predicates;
+
+import java.util.function.Predicate;
+import me.simplq.constants.TokenStatus;
+import me.simplq.dao.Token;
+import me.simplq.exceptions.SQInvalidRequestException;
+
+public class TokenPredicate {
+
+  public Predicate<Token> isNotRemoved() {
+    return token -> {
+      if (TokenStatus.REMOVED.equals(token.getStatus())) {
+        throw SQInvalidRequestException.tokenDeletedException();
+      }
+
+      return true;
+    };
+  }
+}

--- a/simplq/src/test/java/me/simplq/config/TestConfig.java
+++ b/simplq/src/test/java/me/simplq/config/TestConfig.java
@@ -1,8 +1,11 @@
 package me.simplq.config;
 
 import java.io.IOException;
-import javax.servlet.*;
-
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
 import me.simplq.controller.advices.LoggedInUserInfo;
 import me.simplq.service.OwnerService;
 import me.simplq.service.QueueService;

--- a/simplq/src/test/java/me/simplq/service/QueueServiceTest.java
+++ b/simplq/src/test/java/me/simplq/service/QueueServiceTest.java
@@ -16,6 +16,7 @@ import me.simplq.dao.Owner;
 import me.simplq.dao.Queue;
 import me.simplq.dao.QueueRepository;
 import me.simplq.exceptions.SQInvalidRequestException;
+import me.simplq.utils.predicates.QueueThrowingPredicate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -27,17 +28,23 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public class QueueServiceTest {
 
-  @Mock QueueRepository repository;
+  @Mock
+  QueueRepository repository;
 
-  @Mock OwnerService ownerService;
+  @Mock
+  OwnerService ownerService;
 
-  @Mock LoggedInUserInfo loggedInUserInfo;
+  @Mock
+  LoggedInUserInfo loggedInUserInfo;
 
   QueueService queueService;
+  QueueThrowingPredicate queueThrowingPredicate;
+
 
   @BeforeEach
   public void setUp() {
-    queueService = new QueueService(repository, ownerService, loggedInUserInfo);
+    queueService = new QueueService(repository, ownerService, loggedInUserInfo,
+        queueThrowingPredicate);
   }
 
   @DisplayName("Throw queue not found exception if queue does not exists")


### PR DESCRIPTION
Try to use predicates that throw on false conditions, and to define static useEntity factory methods for creating reponse pojos from entities.

The cons of this approach is that layer boundary gets a bit blurred. Some logic moves into entity classes, some logic into the response POJOs. This leads to more DRY code, so LGTM.