### PR TITLE
Move URL_PREFIX to env vars with config fallback (#147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ By default, the jar uses an in-memory H2 database. This is for development purpo
 export DB_USERNAME=<user-name>
 export DB_PASSWORD=<password>
 export DB_URL=jdbc:postgresql://<host>:<port>/<db>
+export TOKEN_URL=<base-token-url>
 java -Dspring.profiles.active=prod -jar simplq/target/simplq-0.0.1-SNAPSHOT.jar 
 ```
 

--- a/simplq/src/main/java/me/simplq/dao/Token.java
+++ b/simplq/src/main/java/me/simplq/dao/Token.java
@@ -20,8 +20,6 @@ import org.hibernate.annotations.GenericGenerator;
 @NoArgsConstructor
 public class Token {
 
-  private static final String URL_PREFIX = "https://simplq.me/token/";
-
   @Id
   @GeneratedValue(generator = "uuid2")
   @GenericGenerator(name = "uuid2", strategy = "uuid2")
@@ -48,10 +46,6 @@ public class Token {
     this.notifiable = notifiable;
     this.ownerId = ownerId;
     this.tokenCreationTimestamp = new Date();
-  }
-
-  public String getTokenUrl() {
-    return URL_PREFIX + tokenId;
   }
 
   public Long getAheadCount() {

--- a/simplq/src/main/java/me/simplq/service/message/EndWaitingMessage.java
+++ b/simplq/src/main/java/me/simplq/service/message/EndWaitingMessage.java
@@ -1,0 +1,17 @@
+package me.simplq.service.message;
+
+class EndWaitingMessage implements Message {
+
+  private static final String FORMAT = "Hi, your wait for %s is over! You can proceed";
+
+  private final String queue;
+
+  public EndWaitingMessage(String queue) {
+    this.queue = queue;
+  }
+
+  @Override
+  public String text() {
+    return String.format(FORMAT, queue);
+  }
+}

--- a/simplq/src/main/java/me/simplq/service/message/Message.java
+++ b/simplq/src/main/java/me/simplq/service/message/Message.java
@@ -1,0 +1,5 @@
+package me.simplq.service.message;
+
+public interface Message {
+  String text();
+}

--- a/simplq/src/main/java/me/simplq/service/message/MessagesManager.java
+++ b/simplq/src/main/java/me/simplq/service/message/MessagesManager.java
@@ -1,9 +1,8 @@
 package me.simplq.service.message;
 
+import java.net.URI;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-
-import java.net.URI;
 
 @Component
 public class MessagesManager {

--- a/simplq/src/main/java/me/simplq/service/message/MessagesManager.java
+++ b/simplq/src/main/java/me/simplq/service/message/MessagesManager.java
@@ -1,0 +1,28 @@
+package me.simplq.service.message;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+
+@Component
+public class MessagesManager {
+
+  private final String tokenUrlPrefix;
+
+  public MessagesManager(@Value("${token.url}") String tokenUrlPrefix) {
+    this.tokenUrlPrefix = tokenUrlPrefix;
+  }
+
+  public Message endWaiting(String queue) {
+    return new EndWaitingMessage(queue);
+  }
+
+  public Message startWaiting(String name, String queueName, Integer tokenNumber, String tokenId) {
+    return new StartWaitingMessage(name, queueName, tokenNumber, tokenUrl(tokenId));
+  }
+
+  private String tokenUrl(String tokenId) {
+    return URI.create(tokenUrlPrefix).resolve(tokenId).toString();
+  }
+}

--- a/simplq/src/main/java/me/simplq/service/message/StartWaitingMessage.java
+++ b/simplq/src/main/java/me/simplq/service/message/StartWaitingMessage.java
@@ -1,0 +1,27 @@
+package me.simplq.service.message;
+
+class StartWaitingMessage implements Message {
+
+  private static final String FORMAT =
+      "Hi %s,\n"
+          + "You have been added to %s. Your token number is %d. You can know your status visiting"
+          + " %s\n"
+          + "Thanks for using simplq.me";
+
+  private final String name;
+  private final String queue;
+  private final Integer tokenNumber;
+  private final String tokenUrl;
+
+  public StartWaitingMessage(String name, String queue, Integer tokenNumber, String tokenUrl) {
+    this.name = name;
+    this.queue = queue;
+    this.tokenNumber = tokenNumber;
+    this.tokenUrl = tokenUrl;
+  }
+
+  @Override
+  public String text() {
+    return String.format(FORMAT, name, queue, tokenNumber, tokenUrl);
+  }
+}

--- a/simplq/src/main/resources/application.properties
+++ b/simplq/src/main/resources/application.properties
@@ -8,3 +8,5 @@ spring.datasource.username=${DB_USERNAME:admin}
 spring.datasource.password=${DB_PASSWORD:password}
 
 spring.liquibase.enabled=false
+
+token.url = ${TOKEN_URL:https://simplq.me/token/}

--- a/simplq/src/test/java/me/simplq/service/message/MessagesManagerTest.java
+++ b/simplq/src/test/java/me/simplq/service/message/MessagesManagerTest.java
@@ -1,13 +1,13 @@
 package me.simplq.service.message;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = MessagesManager.class)
@@ -16,8 +16,8 @@ class MessagesManagerTest {
 
   private static final String START_MESSAGE_EXPECTED =
       "Hi test-name,\n"
-          + "You have been added to test-queue. Your token number is 42. You can know your status visiting"
-          + " http://token-test-url/test-token-id\n"
+          + "You have been added to test-queue. Your token number is 42. You can know your status"
+          + " visiting http://token-test-url/test-token-id\n"
           + "Thanks for using simplq.me";
 
   private static final String END_MESSAGE_EXPECTED =

--- a/simplq/src/test/java/me/simplq/service/message/MessagesManagerTest.java
+++ b/simplq/src/test/java/me/simplq/service/message/MessagesManagerTest.java
@@ -1,0 +1,45 @@
+package me.simplq.service.message;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = MessagesManager.class)
+@TestPropertySource(properties = {"token.url=http://token-test-url/"})
+class MessagesManagerTest {
+
+  private static final String START_MESSAGE_EXPECTED =
+      "Hi test-name,\n"
+          + "You have been added to test-queue. Your token number is 42. You can know your status visiting"
+          + " http://token-test-url/test-token-id\n"
+          + "Thanks for using simplq.me";
+
+  private static final String END_MESSAGE_EXPECTED =
+      "Hi, your wait for test-queue is over! You can proceed";
+
+  @Autowired private MessagesManager manager;
+
+  @Test
+  void endWaiting() {
+    Message message = manager.endWaiting("test-queue");
+
+    assertThat(message).isInstanceOf(EndWaitingMessage.class);
+    assertThat(message).isNotNull();
+    assertThat(message.text()).isEqualTo(END_MESSAGE_EXPECTED);
+  }
+
+  @Test
+  void startWaiting() {
+    Message message = manager.startWaiting("test-name", "test-queue", 42, "test-token-id");
+
+    assertThat(message).isInstanceOf(StartWaitingMessage.class);
+    assertThat(message).isNotNull();
+    assertThat(message.text()).isEqualTo(START_MESSAGE_EXPECTED);
+  }
+}

--- a/simplq/src/test/resources/application.properties
+++ b/simplq/src/test/resources/application.properties
@@ -2,3 +2,5 @@ spring.datasource.url=jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1;
 spring.datasource.username=sa
 spring.datasource.password=
 spring.datasource.driverClassName=org.h2.Driver
+
+token.url=${TOKEN_URL:https://simplq.me/token/}


### PR DESCRIPTION
- Moved hardcoded url to TOKEN_URL environment variable with fallback on application.properties config value;
- Moved message creation logic to separate component;
- Separated message creation logic from token creation/notification use-case;
- Edited readme (added TOKEN_URL env var explanation);
- Added unit-test;