### PR TITLE
Queue History (#126)

### DIFF
--- a/simplq/src/main/java/me/simplq/controller/model/queue/QueueDetailsResponse.java
+++ b/simplq/src/main/java/me/simplq/controller/model/queue/QueueDetailsResponse.java
@@ -31,9 +31,10 @@ public class QueueDetailsResponse {
   private final Long slotsLeft;
   private final boolean isSelfJoinAllowed;
   private final List<Token> tokens = new ArrayList<>();
+  private final List<Token> removedTokens = new ArrayList<>();
 
   public void addToken(me.simplq.dao.Token token) {
-    this.tokens.add(
+    Token newToken =
         new Token(
             token.getName(),
             token.getContactNumber(),
@@ -41,7 +42,13 @@ public class QueueDetailsResponse {
             token.getTokenNumber(),
             token.getTokenCreationTimestamp(),
             token.getStatus(),
-            token.getNotifiable()));
+            token.getNotifiable());
+
+    if (TokenStatus.REMOVED.equals(token.getStatus())) {
+      this.removedTokens.add(newToken);
+    } else {
+      this.tokens.add(newToken);
+    }
   }
 
   public static QueueDetailsResponse fromEntity(Queue queue) {
@@ -55,7 +62,6 @@ public class QueueDetailsResponse {
             queue.getSlotsLeft(),
             queue.isSelfJoinAllowed());
     queue.getTokens().stream()
-        .filter(token -> token.getStatus() != TokenStatus.REMOVED)
         .sorted(Comparator.comparing(me.simplq.dao.Token::getTokenCreationTimestamp))
         .forEach(response::addToken);
     return response;

--- a/simplq/src/main/java/me/simplq/dao/Token.java
+++ b/simplq/src/main/java/me/simplq/dao/Token.java
@@ -38,6 +38,10 @@ public class Token {
   @Temporal(TemporalType.TIMESTAMP)
   Date tokenCreationTimestamp;
 
+  @Column(updatable = false)
+  @Temporal(TemporalType.TIMESTAMP)
+  Date tokenDeletionTimestamp;
+
   public Token(
       String name, String contactNumber, TokenStatus status, Boolean notifiable, String ownerId) {
     this.name = name;
@@ -58,5 +62,10 @@ public class Token {
                 fellowUser.getTokenCreationTimestamp().before(this.getTokenCreationTimestamp())
                     && !fellowUser.getStatus().equals(TokenStatus.REMOVED))
         .count();
+  }
+
+  public void delete() {
+    this.status = TokenStatus.REMOVED;
+    this.tokenDeletionTimestamp = new Date();
   }
 }

--- a/simplq/src/main/java/me/simplq/service/TokenService.java
+++ b/simplq/src/main/java/me/simplq/service/TokenService.java
@@ -51,13 +51,14 @@ public class TokenService {
 
   @Transactional
   public TokenDeleteResponse deleteToken(String tokenId) {
-    tokenRepository.setTokenStatusById(TokenStatus.REMOVED, tokenId);
     return tokenRepository
         .findById(tokenId)
         .map(
-            token ->
-                new TokenDeleteResponse(
-                    tokenId, token.getQueue().getQueueName(), token.getStatus()))
+            token -> {
+              token.delete();
+              return new TokenDeleteResponse(
+                  tokenId, token.getQueue().getQueueName(), token.getStatus());
+            })
         .orElseThrow(SQInternalServerException::new);
   }
 


### PR DESCRIPTION
1. Moved token resolution to addToken method
2. Added tokenDeletionTimestamp
3. No need to call save() in deleteToken method - token entity is managed
4. Added token.delete method